### PR TITLE
pos_sale_order: correct partner on pos_payment

### DIFF
--- a/pos_sale_order/models/pos_payment.py
+++ b/pos_sale_order/models/pos_payment.py
@@ -18,7 +18,9 @@ class PosPayment(models.Model):
     payment_method_id = fields.Many2one(readonly=True)
     pos_order_id = fields.Many2one(required=False)
     session_id = fields.Many2one(related=False, readonly=True)
-    partner_id = fields.Many2one(related="pos_sale_order_id.partner_id")
+    partner_id = fields.Many2one(
+        related="pos_sale_order_id.partner_invoice_id.commercial_partner_id"
+    )
     company_id = fields.Many2one(related="pos_sale_order_id.company_id")
     currency_id = fields.Many2one(related="pos_sale_order_id.currency_id")
     currency_rate = fields.Float(related="pos_sale_order_id.currency_rate")

--- a/pos_sale_order/models/pos_payment.py
+++ b/pos_sale_order/models/pos_payment.py
@@ -18,7 +18,7 @@ class PosPayment(models.Model):
     payment_method_id = fields.Many2one(readonly=True)
     pos_order_id = fields.Many2one(required=False)
     session_id = fields.Many2one(related=False, readonly=True)
-    partner_id = fields.Many2one(related="pos_sale_order_id.partner_invoice_id")
+    partner_id = fields.Many2one(related="pos_sale_order_id.partner_id")
     company_id = fields.Many2one(related="pos_sale_order_id.company_id")
     currency_id = fields.Many2one(related="pos_sale_order_id.currency_id")
     currency_rate = fields.Float(related="pos_sale_order_id.currency_rate")


### PR DESCRIPTION
It should not be the invoice partner.

Otherwise, it creates difficulties with
account_reconcile_restrict_partner_mismatch

Aligned with point_of_sale_module: (models/pos_payment.py)
    partner_id = fields.Many2one(related='pos_order_id.partner_id')