### PR TITLE
[14.0] [FIX] pos_sale_order_delivery: Handle multi move_line_ids in deliver_all

### DIFF
--- a/pos_sale_order_delivery/models/sale_order.py
+++ b/pos_sale_order_delivery/models/sale_order.py
@@ -67,5 +67,10 @@ class SaleOrder(models.Model):
     def action_deliver_all(self):
         for picking in self.picking_ids:
             for line in picking.move_lines:
-                line.quantity_done = line.product_uom_qty
+                if len(line.move_line_ids) > 1:
+                    # Handle multiple move lines
+                    for move_line in line.move_line_ids:
+                        move_line.qty_done = move_line.product_uom_qty
+                else:
+                    line.quantity_done = line.product_uom_qty
             picking.button_validate()


### PR DESCRIPTION
To prevent `UserError: Cannot set the done quantity from this stock move, work directly with the move lines.` in https://github.com/odoo/odoo/blob/14.0/addons/stock/models/stock_move.py#L363-L368