### PR TITLE
[14.0] [FIX] pos_sale_order: Fix deadlock on session close with a payment method without journal

### DIFF
--- a/pos_sale_order/models/pos_payment_method.py
+++ b/pos_sale_order/models/pos_payment_method.py
@@ -14,3 +14,10 @@ class PosPaymentMethod(models.Model):
     split_transactions = fields.Boolean(
         help="If ticked, each payment will generate a separated journal item."
     )
+
+    def _is_write_forbidden(self, fields):
+        # Avoid deadlock when closing a session on a payment method without
+        # cash journal
+        if fields == {"cash_journal_id"} and not self.cash_journal_id:
+            return False
+        return super()._is_write_forbidden(fields)


### PR DESCRIPTION
We should at least allow setting a journal, otherwise the session can't be close since there is no journal and journal can't be set since there's an open session.