### PR TITLE
[14.0][IMP] pos_sale_order: support multi-steps delivery in `pos.delivery.wizard`

### DIFF
--- a/pos_sale_order/i18n/fr.po
+++ b/pos_sale_order/i18n/fr.po
@@ -144,10 +144,10 @@ msgstr "Fait"
 #: code:addons/pos_sale_order/wizards/pos_delivery_wizard.py:0
 #, fuzzy, python-format
 msgid ""
-"Fail to deliver picking have been split, please do it from delivery menu"
+"Operation %s cannot be validated automatically, please do it from delivery menu"
 msgstr ""
-"Impossible de livrer une commande avec plusieurs bon de livraison, veuiller "
-"le traiter depuis le menu livraison"
+"L'opération %s ne peut pas être validée automatiquement, veuillez la traiter "
+"depuis le menu livraison"
 
 #. module: pos_sale_order
 #: code:addons/pos_sale_order/models/sale_order.py:0

--- a/pos_sale_order/i18n/pos_sale_order.pot
+++ b/pos_sale_order/i18n/pos_sale_order.pot
@@ -140,7 +140,7 @@ msgstr ""
 #: code:addons/pos_sale_order/wizards/pos_delivery_wizard.py:0
 #, python-format
 msgid ""
-"Fail to deliver picking have been split, please do it from delivery menu"
+"Operation %s cannot be validated automatically, please do it from delivery menu"
 msgstr ""
 
 #. module: pos_sale_order

--- a/pos_sale_order/tests/__init__.py
+++ b/pos_sale_order/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_create_order
 from . import test_closing_session
+from . import test_pos_delivery_wizard

--- a/pos_sale_order/tests/test_pos_delivery_wizard.py
+++ b/pos_sale_order/tests/test_pos_delivery_wizard.py
@@ -1,0 +1,192 @@
+# Copyright 2026  Akretion (https://www.akretion.com).
+# @author Sébastien Alix <sebastien.alix@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo.tests.common import tagged
+
+from .common import CommonCase
+
+
+@tagged("-at_install", "post_install")
+class TestPosDeliveryWizard(CommonCase):
+    def test_create_wizard_from_sale(self):
+        data = self._get_pos_data()
+        sale = self._create_sale([data])
+        sale.action_confirm()
+        self.assertTrue(sale.picking_ids)
+        wizard = self.env["pos.delivery.wizard"].create_wizard(sale)
+        self.assertEqual(len(wizard.line_ids), 3)
+        for line in wizard.line_ids:
+            self.assertEqual(line.qty, line.move_line_id.product_uom_qty)
+            self.assertEqual(line.product_id, line.move_line_id.product_id)
+
+    def test_create_wizard_exclude_done_picking(self):
+        data = self._get_pos_data()
+        sale = self._create_sale([data])
+        sale.action_confirm()
+        for picking in sale.picking_ids:
+            for move in picking.move_lines:
+                move.quantity_done = move.product_uom_qty
+            picking.button_validate()
+        wizard = self.env["pos.delivery.wizard"].create_wizard(sale)
+        self.assertEqual(len(wizard.line_ids), 0)
+
+    def test_create_wizard_exclude_cancel_picking(self):
+        data = self._get_pos_data()
+        sale = self._create_sale([data])
+        sale.action_confirm()
+        for picking in sale.picking_ids:
+            picking.action_cancel()
+        wizard = self.env["pos.delivery.wizard"].create_wizard(sale)
+        self.assertEqual(len(wizard.line_ids), 0)
+
+    def test_confirm_wizard(self):
+        """Test basic delivery."""
+        data = self._get_pos_data()
+        sale = self._create_sale([data])
+        sale.action_confirm()
+        wizard = self.env["pos.delivery.wizard"].create_wizard(sale)
+        self.assertEqual(len(wizard.line_ids), 3)
+        for line in wizard.line_ids:
+            self.assertEqual(line.move_line_id.quantity_done, 0)
+        wizard.confirm()
+        for line in wizard.line_ids:
+            self.assertEqual(line.move_line_id.quantity_done, line.qty)
+        for picking in sale.picking_ids:
+            self.assertEqual(picking.state, "done")
+
+    def test_confirm_wizard_partial_delivery(self):
+        """Test partial delivery."""
+        data = self._get_pos_data()
+        sale = self._create_sale([data])
+        sale.action_confirm()
+        delivery = sale.picking_ids
+        wizard = self.env["pos.delivery.wizard"].create_wizard(sale)
+        self.assertEqual(len(wizard.line_ids), 3)
+        # Remove one product from the delivery
+        move_to_skip = wizard.line_ids[-1].move_line_id
+        current_picking = move_to_skip.picking_id
+        wizard.line_ids[-1].unlink()
+        for line in wizard.line_ids:
+            self.assertEqual(line.move_line_id.quantity_done, 0)
+        wizard.confirm()
+        # Check delivery
+        for line in wizard.line_ids:
+            self.assertEqual(line.move_line_id.quantity_done, line.qty)
+        self.assertEqual(len(sale.picking_ids), 2)
+        self.assertEqual(delivery.state, "done")
+        # Unprocessed move has been put in a backorder
+        backorder = delivery.backorder_ids
+        self.assertEqual(backorder.state, "confirmed")
+        self.assertIn(move_to_skip, backorder.move_lines)
+        self.assertEqual(move_to_skip.quantity_done, 0)
+        self.assertNotEqual(move_to_skip.picking_id, current_picking)
+
+    def test_confirm_wizard_partial_qty_delivery(self):
+        """Test partial qty delivery."""
+        data = self._get_pos_data()
+        sale = self._create_sale([data])
+        sale.action_confirm()
+        delivery = sale.picking_ids
+        wizard = self.env["pos.delivery.wizard"].create_wizard(sale)
+        self.assertEqual(len(wizard.line_ids), 3)
+        # Ship 1 unit over 2
+        line_product2 = wizard.line_ids.filtered(
+            lambda l: l.product_id == self.product2
+        )
+        move_product2 = line_product2.move_line_id
+        line_product2.qty = 1  # Ship 1 unit instead of 2
+        for line in wizard.line_ids:
+            self.assertEqual(line.move_line_id.quantity_done, 0)
+        wizard.confirm()
+        # Check delivery
+        self.assertEqual(len(sale.picking_ids), 2)
+        self.assertEqual(delivery.state, "done")
+        self.assertEqual(move_product2.quantity_done, 1)
+        self.assertEqual(move_product2.product_uom_qty, 1)
+        # Unprocessed qty has been put in a backorder
+        backorder = delivery.backorder_ids
+        self.assertEqual(backorder.state, "confirmed")
+        self.assertEqual(backorder.move_lines.product_id, self.product2)
+        self.assertEqual(backorder.move_lines.product_uom_qty, 1)
+
+    def test_confirm_wizard_with_pick_ship_delivery(self):
+        """Test multi-steps delivery (pick+ship)."""
+        data = self._get_pos_data()
+        sale = self._create_sale([data])
+        sale.warehouse_id.delivery_steps = "pick_ship"
+        sale.action_confirm()
+        location = sale.warehouse_id.lot_stock_id
+        for product in sale.picking_ids.product_id:
+            self.env["stock.quant"]._update_available_quantity(product, location, 100)
+        sale.picking_ids.action_assign()
+        wizard = self.env["pos.delivery.wizard"].create_wizard(sale)
+        self.assertEqual(len(wizard.line_ids), 3)
+        # Remove one product from the delivery
+        move_to_skip = wizard.line_ids[-1].move_line_id
+        current_picking = move_to_skip.picking_id
+        wizard.line_ids[-1].unlink()
+        for line in wizard.line_ids:
+            self.assertEqual(line.move_line_id.quantity_done, 0)
+        wizard.confirm()
+        for line in wizard.line_ids:
+            self.assertEqual(line.move_line_id.quantity_done, line.qty)
+        # Unprocessed move has been put in a backorder
+        self.assertEqual(move_to_skip.quantity_done, 0)
+        self.assertNotEqual(move_to_skip.picking_id, current_picking)
+        self.assertEqual(len(sale.picking_ids), 4)
+        deliveries = sale.picking_ids.filtered(
+            lambda p: p.picking_type_code == "outgoing"
+        )
+        self.assertEqual(len(deliveries), 2)
+        self.assertTrue("waiting" in deliveries.mapped("state"))
+        self.assertTrue("done" in deliveries.mapped("state"))
+
+    def test_confirm_wizard_with_pick_ship_partial_delivery(self):
+        """Test multi-steps partial delivery (pick+ship)."""
+        data = self._get_pos_data()
+        sale = self._create_sale([data])
+        sale.warehouse_id.delivery_steps = "pick_ship"
+        sale.action_confirm()
+        location = sale.warehouse_id.lot_stock_id
+        for product in sale.picking_ids.product_id:
+            self.env["stock.quant"]._update_available_quantity(product, location, 100)
+        sale.picking_ids.action_assign()
+        wizard = self.env["pos.delivery.wizard"].create_wizard(sale)
+        self.assertEqual(len(wizard.line_ids), 3)
+        for line in wizard.line_ids:
+            self.assertEqual(line.move_line_id.quantity_done, 0)
+        wizard.confirm()
+        for line in wizard.line_ids:
+            self.assertEqual(line.move_line_id.quantity_done, line.qty)
+        for picking in sale.picking_ids:
+            self.assertEqual(picking.state, "done")
+
+    def test_confirm_wizard_with_pick_pack_ship_delivery(self):
+        """Test multi-steps delivery (pick+pack+ship)."""
+        data = self._get_pos_data()
+        sale = self._create_sale([data])
+        sale.warehouse_id.delivery_steps = "pick_pack_ship"
+        sale.action_confirm()
+        location = sale.warehouse_id.lot_stock_id
+        for product in sale.picking_ids.product_id:
+            self.env["stock.quant"]._update_available_quantity(product, location, 100)
+        sale.picking_ids.action_assign()
+        wizard = self.env["pos.delivery.wizard"].create_wizard(sale)
+        self.assertEqual(len(wizard.line_ids), 3)
+        for line in wizard.line_ids:
+            self.assertEqual(line.move_line_id.quantity_done, 0)
+        wizard.confirm()
+        for line in wizard.line_ids:
+            self.assertEqual(line.move_line_id.quantity_done, line.qty)
+        for picking in sale.picking_ids:
+            self.assertEqual(picking.state, "done")
+
+    def test_open_pos_delivery_wizard(self):
+        data = self._get_pos_data()
+        sale = self._create_sale([data])
+        sale.action_confirm()
+        action = sale.open_pos_delivery_wizard()
+        self.assertIn("res_id", action)
+        wizard = self.env["pos.delivery.wizard"].browse(action["res_id"])
+        self.assertEqual(len(wizard.line_ids), 3)

--- a/pos_sale_order/wizards/pos_delivery_wizard.py
+++ b/pos_sale_order/wizards/pos_delivery_wizard.py
@@ -31,23 +31,69 @@ class PosDeliveryWizard(models.TransientModel):
                         vals.append([0, 0, self._prepare_line(line)])
         return self.create({"line_ids": vals})
 
+    def _get_first_moves(self):
+        # NOTE: deliveries of SO could be a mixed of {one,two,three,...} steps operations
+        moves = self.line_ids.move_line_id
+        first_moves = moves.browse()
+        while moves:
+            first_moves = moves.move_orig_ids | moves.filtered(
+                lambda m: not m.move_orig_ids
+            )
+            moves = first_moves - moves
+        return first_moves
+
+    def _set_moves_qty_done(self, moves):
+        for move in moves:
+            if move.move_line_ids:
+                for line in move.move_line_ids:
+                    # Do not change anything if the move line has been created
+                    # manually (forced) or if the qty done has already been set
+                    if not line.product_qty or line.qty_done:
+                        continue
+                    line.qty_done = line.product_qty
+            elif move.state == "confirmed":  # Ignore 'waiting' moves
+                move.quantity_done = move.product_uom_qty
+
+    def _handle_button_validate_action(self, action):
+        if action.get("res_model") == "stock.backorder.confirmation":
+            ctx = action.get("context", {})
+            wiz = self.env[action["res_model"]].with_context(**ctx).create({})
+            wiz.process()
+
+    def _validate_delivery(self):
+        """Validate all chained stock operations.
+
+        It starts with the first one of the chain following pull rules scheme.
+
+        `UserError` is raised if at least one operation could not be processed.
+        """
+        first_moves = self._get_first_moves()
+        moves_to_validate = first_moves
+        while moves_to_validate:
+            for picking in moves_to_validate.picking_id:
+                if picking.state in ("done", "cancel"):
+                    continue
+                if picking.state == "confirmed":
+                    picking.action_assign()
+                self._set_moves_qty_done(moves_to_validate)
+                res = picking.button_validate()
+                if res is not True:  # Action
+                    self._handle_button_validate_action(res)
+                if picking.state != "done":
+                    raise UserError(
+                        _(
+                            "Operation %s cannot be validated automatically,"
+                            " please do it from delivery menu"
+                        )
+                        % picking.name
+                    )
+            moves_to_validate = moves_to_validate.move_dest_ids
+
     def confirm(self):
         for line in self.line_ids:
             line.move_line_id.quantity_done = line.qty
-        res = None
-        for picking in self.mapped("line_ids.move_line_id.picking_id"):
-            result = picking.button_validate()
-            if result:
-                if res is None:
-                    res = result
-                else:
-                    raise UserError(
-                        _(
-                            "Fail to deliver picking have been split, please do it "
-                            "from delivery menu"
-                        )
-                    )
-        return res
+        self._validate_delivery()
+        return True
 
 
 class PosDeliveryWizardLine(models.TransientModel):


### PR DESCRIPTION
Pos Delivery Wizard is now able to validate multi-steps deliveries linked to current sale order.

Please merge that one at first, I'll rebase on top of it afterwards :
- https://github.com/akretion/pos-sale-order/pull/79